### PR TITLE
Add explicit flag and source for bpy in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,3 +82,7 @@ asyncio_default_fixture_loop_scope = "function"
 [[tool.uv.index]]
 name = "blender"
 url = "https://download.blender.org/pypi/"
+explicit = true 
+
+[tool.uv.sources]
+bpy = { index = "blender" }                                                                                                                                                                                               


### PR DESCRIPTION
The original script would give the following error when installing sam3d: 

```bash
error: Request failed after 3 retries
  Caused by: Failed to fetch: `https://download.blender.org/pypi/nvidia-nvtx-cu12/`
  Caused by: HTTP status client error (429 Too Many Requests) for url (https://download.blender.org/pypi/nvidia-nvtx-cu12/)
```

The change here would stop UV from hitting download.blender.org for CUDA packages and resolve the rate limiting error. 